### PR TITLE
#3800: support for referenced splice files

### DIFF
--- a/DGGraphImpl.h
+++ b/DGGraphImpl.h
@@ -281,7 +281,10 @@ namespace FabricSpliceImpl
 
     /// constructs the node based on a persisted JSON file
     /// you need to pass in thisGraph as a shared pointer to avoid cycles in reference counting.
-    bool loadFromFile(DGGraphImplPtr thisGraph, const std::string & filePath, PersistenceInfo * info = NULL, std::string * errorOut = NULL);
+    bool loadFromFile(DGGraphImplPtr thisGraph, const std::string & filePath, PersistenceInfo * info = NULL, bool asReferenced = false, std::string * errorOut = NULL);
+
+    /// returns true if this graph is referenced from a file
+    bool isReferenced();
 
     /// request an evaluation on idle
     bool requireEvaluate();
@@ -395,6 +398,8 @@ namespace FabricSpliceImpl
     std::string mMetaData;
     FabricCore::RTVal mEvalContext;
     stringMap mKLOperatorFileNames;
+    bool mIsReferenced;
+    std::string mFilePath;
 
     // static members
     static DGOperatorSuffixMap sDGOperatorSuffix;
@@ -412,8 +417,8 @@ namespace FabricSpliceImpl
 
     // utilities
     bool memberPersistence(const std::string &name, const std::string &type, bool * requiresStorage = NULL);
-    std::string resolveRelativePath(const std::string & baseFile, const std::string text);
-    std::string resolveEnvironmentVariables(const std::string text);
+    static std::string resolveRelativePath(const std::string & baseFile, const std::string text);
+    static std::string resolveEnvironmentVariables(const std::string text);
   };
 };
 

--- a/FabricSplice.cpp
+++ b/FabricSplice.cpp
@@ -1933,11 +1933,19 @@ bool FECS_DGGraph_saveToFile(FECS_DGGraphRef ref, const char * filePath, const F
   FECS_CATCH(false);
 }
 
-bool FECS_DGGraph_loadFromFile(FECS_DGGraphRef ref, const char * filePath, FECS_PersistenceInfo * info)
+bool FECS_DGGraph_loadFromFile(FECS_DGGraphRef ref, const char * filePath, FECS_PersistenceInfo * info, bool asReferenced)
 {
   FECS_TRY_CLEARERROR
   GETSMARTPTR(DGGraphImplPtr, graph, false)
-  return graph->loadFromFile(graph, filePath, (DGGraphImpl::PersistenceInfo *)info);
+  return graph->loadFromFile(graph, filePath, (DGGraphImpl::PersistenceInfo *)info, asReferenced);
+  FECS_CATCH(false);
+}
+
+FECS_DECL bool FECS_DGGraph_isReferenced(FECS_DGGraphRef ref)
+{
+  FECS_TRY_CLEARERROR
+  GETSMARTPTR(DGGraphImplPtr, graph, false)
+  return graph->isReferenced();
   FECS_CATCH(false);
 }
 

--- a/FabricSplice.h
+++ b/FabricSplice.h
@@ -1611,7 +1611,10 @@ Class Outline
         bool saveToFile(const char * filePath, const PersistenceInfo * info = NULL);
 
         // constructs the node based on a persisted JSON file
-        bool loadFromFile(const char * filePath, PersistenceInfo * info = NULL);
+        bool loadFromFile(const char * filePath, PersistenceInfo * info = NULL, bool asReferenced = false);
+
+        // returns true if this graph is referenced from a file
+        bool isReferenced();
 
         // marks a member to be persisted
         void setMemberPersistence(const char * name, bool persistence);
@@ -1951,7 +1954,8 @@ FECS_DECL char * FECS_DGGraph_getPersistenceDataJSON(FECS_DGGraphRef ref, const 
 FECS_DECL bool FECS_DGGraph_setFromPersistenceDataDict(FECS_DGGraphRef ref, const FabricCore::Variant & dict, FECS_PersistenceInfo * info, const char * baseFilePath);
 FECS_DECL bool FECS_DGGraph_setFromPersistenceDataJSON(FECS_DGGraphRef ref, const char * json, FECS_PersistenceInfo * info, const char * baseFilePath);
 FECS_DECL bool FECS_DGGraph_saveToFile(FECS_DGGraphRef ref, const char * filePath, const FECS_PersistenceInfo * info);
-FECS_DECL bool FECS_DGGraph_loadFromFile(FECS_DGGraphRef ref, const char * filePath, FECS_PersistenceInfo * info);
+FECS_DECL bool FECS_DGGraph_loadFromFile(FECS_DGGraphRef ref, const char * filePath, FECS_PersistenceInfo * info, bool asReferenced);
+FECS_DECL bool FECS_DGGraph_isReferenced(FECS_DGGraphRef ref);
 FECS_DECL void FECS_DGGraph_setMemberPersistence(FECS_DGGraphRef ref, const char * name, bool persistence);
 
 FECS_DECL FECS_DGPortRef FECS_DGPort_copy(FECS_DGPortRef ref);
@@ -4584,9 +4588,17 @@ namespace FabricSplice
     }
 
     // constructs the node based on a persisted JSON file
-    bool loadFromFile(const char * filePath, PersistenceInfo * info = NULL)
+    bool loadFromFile(const char * filePath, PersistenceInfo * info = NULL, bool asReferenced = false)
     {
-      bool result = FECS_DGGraph_loadFromFile(mRef, filePath, info);
+      bool result = FECS_DGGraph_loadFromFile(mRef, filePath, info, asReferenced);
+      Exception::MaybeThrow();
+      return result;
+    }
+
+    // returns true if this graph is referenced from a file
+    bool isReferenced()
+    {
+      bool result = FECS_DGGraph_isReferenced(mRef);
       Exception::MaybeThrow();
       return result;
     }


### PR DESCRIPTION
@pzion support for referenced splice files - instead of loading the content from the given json, we load it from another referenced files. the DCC persistence content will be only the splice file path at that point. 

unit test is here: https://github.com/fabric-engine/SceneGraph/commit/3f9c7e1e97d0a6991cc430f930aefefdbbcacd3e